### PR TITLE
devprod/changes required to build/publish drizzle-kit@0.31.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-@drizzle-team:registry=https://us-central1-npm.pkg.dev/marine-cycle-160323/replit-internal/
-//us-central1-npm.pkg.dev/marine-cycle-160323/replit-internal/:always-auth=true
-# prefer-workspace-packages = true

--- a/README.md
+++ b/README.md
@@ -17,44 +17,12 @@
 
 ### Replit development
 
-We use `drizzle-kit` for handling database migrations. However in order expose `drizzle-kit`s internal functions (which are not exported by default) they suggested cloning the `drizzle-orm` repo and making our changes just to the one `drizzle-kit/api` file ([see here](./drizzle-kit/src/api.ts)) to build an external API particular for our use case. 
+We use `drizzle-kit` for handling database migrations. However in order expose `drizzle-kit`s internal functions (which are not exported by default) they suggested cloning the `drizzle-orm` repo and making our changes just to the `drizzle-kit/api` file ([see here](./drizzle-kit/src/api.ts)) to build an external API particular for our use case.
+
+We do not require/import any of the other packages in this repo.
 
 #### Getting started
-Run the below in the project root:
-
-```bash
-pnpm install && pnpm build
-```
-
-#### Development
-Navigate to `drizzle-kit` and make any changes you require to the `drizzle-kit/api` file ([see here](./drizzle-kit/src/api.ts)), then run:
-```
-pnpm build
-```
-This will build a dist file that you can import into `repl-it-web` using the `file:` protocol in `package.json` like so:
-```
-"@drizzle-team/drizzle-kit": "file:../drizzle-orm/drizzle-kit/dist",
-```
-> [!NOTE]
-> - After any changes to you'll need to run the build command again.
-> - If you're using `drizzle-kit` in pid2 you'll also need to rebuild your pid2 build and re-upload.
-
-#### Publishing changes
-Once your changes have been made, bump the package version in `drizzle-kit/package.json`:
-```
-	"version": "0.31.1",
-```
-Then build and pack your changes via:
-```
-pnpm build && pnpm pack
-```
-This should generate a file ending in `.tgz` in the project root, make sure you rename this file to `package.tgz`, then run:
-```
-npm run login
-npm publish package.tgz --provenance=false
-```
-> [!NOTE]
-> In repl-it-web we scope drizzle packages to our replit-internal npm registry via the @drizzle-team scope, hence we've updated the package name to `@drizzle-team/drizzle-kit` and not just `drizzle-kit`.
+To get started see the `drizzle-kit` ([README.md]./drizzle-kit/README.md).
 
 ### What's Drizzle?
 Drizzle is a modern TypeScript ORM developers [wanna use in their next project](https://stateofdb.com/tools/drizzle). 

--- a/drizzle-kit/README.md
+++ b/drizzle-kit/README.md
@@ -1,3 +1,48 @@
+## Replit development
+Exposing `drizzle-kit` internal functions via the `drizzle-kit/api` file ([see here](./src/api.ts)) for preparing database migrations in the deploy flow.
+
+#### Getting started
+Run the below in the project root:
+
+```bash
+pnpm install && pnpm build
+```
+
+#### Development
+Make any changes you require to the `drizzle-kit/api` file ([see here](./drizzle-kit/src/api.ts)), then run:
+```bash
+pnpm build
+```
+This will build a `dist` file that you can import into `repl-it-web` using the `file:` protocol in `package.json` like so:
+```
+"@drizzle-team/drizzle-kit": "file:../drizzle-orm/drizzle-kit/dist",
+```
+> [!NOTE]
+> - After any changes to you'll need to run the build command again.
+> - If you're using `drizzle-kit` in pid2 you'll also need to rebuild your pid2 build and re-upload.
+
+#### Publishing changes
+Once your changes have been made, bump the package version in `drizzle-kit/package.json`:
+```
+  "version": "0.31.1",
+```
+Then rebuild to make sure the version number is updated:
+```bash
+pnpm build
+```
+Then run the pack command via `npm`:
+```
+npm run pack
+```
+This should generate a file `package.tgz`, then run the following via `npm`:
+```
+npm run login
+npm run publish
+```
+> [!NOTE]
+> - In repl-it-web we scope drizzle packages to our replit-internal npm registry via the @drizzle-team scope, hence we've updated the package name to `@drizzle-team/drizzle-kit` and not just `drizzle-kit`.
+> - Because we don't require the rest of `drizzle-orm` we import it via a package and not the pnpm workspace, e.g `"drizzle-orm": "0.44.1",` vs `"drizzle-orm": "workspace:./drizzle-orm/dist",`. This means we don't have to build the whole drizzle-orm library in order to make changes. If at any point we decide to import more private packages from drizzle-orm then we can revert.
+
 ## Drizzle Kit
 
 Drizzle Kit is a CLI migrator tool for Drizzle ORM. It is probably the one and only tool that lets you completely automatically generate SQL migrations and covers ~95% of the common cases like deletions and renames by prompting user input.

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.2",
+	"version": "0.31.3",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.1",
+	"version": "0.31.2",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",
@@ -38,9 +38,10 @@
 		"test": "pnpm tsc && TEST_CONFIG_PATH_PREFIX=./tests/cli/ vitest",
 		"build": "rm -rf ./dist && tsx build.ts && cp package.json dist/ && attw --pack dist",
 		"build:dev": "rm -rf ./dist && tsx build.dev.ts && tsc -p tsconfig.cli-types.json && chmod +x ./dist/index.cjs",
-		"pack": "cp package.json README.md dist/ && (cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
+		"pack": "cd dist && PACK_FILE=$(npm pack --pack-destination ..) && cd .. && rm -f package.tgz && mv \"$PACK_FILE\" package.tgz",
 		"tsc": "tsc -p tsconfig.build.json --noEmit",
-		"publish": "npm publish package.tgz"
+		"login": "npx google-artifactregistry-auth --repo-config ~/.npmrc",
+		"publish": "npm publish package.tgz --provenance=false"
 	},
 	"dependencies": {
 		"@drizzle-team/brocli": "^0.10.2",
@@ -83,7 +84,7 @@
 		"dockerode": "^4.0.6",
 		"dotenv": "^16.0.3",
 		"drizzle-kit": "0.25.0-b1faa33",
-		"drizzle-orm": "workspace:./drizzle-orm/dist",
+		"drizzle-orm": "0.44.1",
 		"env-paths": "^3.0.0",
 		"esbuild-node-externals": "^1.9.0",
 		"eslint": "^8.57.0",

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -66,8 +66,8 @@ export type NamedWithSchema = {
 };
 
 export const schemasResolver = async (
-	input: ResolverInput<Table>,
-): Promise<ResolverOutput<Table>> => {
+	input: ResolverInput<Named>,
+): Promise<ResolverOutput<Named>> => {
 	try {
 		const { created, deleted, renamed } = await promptSchemasConflict(
 			input.created,

--- a/drizzle-kit/src/cli/connections.ts
+++ b/drizzle-kit/src/cli/connections.ts
@@ -167,16 +167,16 @@ export const preparePostgresDB = async (
 			// @ts-ignore
 			getTypeParser: (typeId, format) => {
 				if (typeId === pg.types.builtins.TIMESTAMPTZ) {
-					return (val) => val;
+					return (val: any) => val;
 				}
 				if (typeId === pg.types.builtins.TIMESTAMP) {
-					return (val) => val;
+					return (val: any) => val;
 				}
 				if (typeId === pg.types.builtins.DATE) {
-					return (val) => val;
+					return (val: any) => val;
 				}
 				if (typeId === pg.types.builtins.INTERVAL) {
-					return (val) => val;
+					return (val: any) => val;
 				}
 				// @ts-ignore
 				return pg.types.getTypeParser(typeId, format);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -244,8 +244,8 @@ importers:
         specifier: 0.25.0-b1faa33
         version: 0.25.0-b1faa33
       drizzle-orm:
-        specifier: workspace:./drizzle-orm/dist
-        version: link:drizzle-orm/dist
+        specifier: 0.44.1
+        version: 0.44.1(202f5f917ad7b147b6fd5e02d382b3b3)
       env-paths:
         specifier: ^3.0.0
         version: 3.0.0
@@ -4283,6 +4283,98 @@ packages:
       pg:
         optional: true
       postgres:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  drizzle-orm@0.44.1:
+    resolution: {integrity: sha512-prIWOlwJbiYInvcJxE+IMiJCtMiFVrSUJCwx6AXSJvGOdLu35qZ46QncTZDgloiLNCG0XxTC8agQElSmsl++TA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
         optional: true
       sql.js:
         optional: true
@@ -9900,6 +9992,13 @@ snapshots:
       react: 18.3.1
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
+  '@expo/vector-icons@14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
+    dependencies:
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
+
   '@expo/websql@1.0.1':
     dependencies:
       argsarray: 0.0.1
@@ -10229,6 +10328,12 @@ snapshots:
       react: 18.3.1
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
+  '@op-engineering/op-sqlite@2.0.22(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
+
   '@opentelemetry/api@1.9.0': {}
 
   '@originjs/vite-plugin-commonjs@1.0.3':
@@ -10427,6 +10532,14 @@ snapshots:
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
     optionalDependencies:
       '@types/react': 18.3.23
+
+  '@react-native/virtualized-lists@0.79.2(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)':
+    dependencies:
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
 
   '@rollup/plugin-terser@0.4.4(rollup@3.29.5)':
     dependencies:
@@ -12520,6 +12633,38 @@ snapshots:
       sql.js: 1.13.0
       sqlite3: 5.1.7
 
+  drizzle-orm@0.44.1(202f5f917ad7b147b6fd5e02d382b3b3):
+    optionalDependencies:
+      '@aws-sdk/client-rds-data': 3.821.0
+      '@cloudflare/workers-types': 4.20250603.0
+      '@electric-sql/pglite': 0.2.12
+      '@libsql/client': 0.10.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@libsql/client-wasm': 0.10.0
+      '@neondatabase/serverless': 0.9.5
+      '@op-engineering/op-sqlite': 2.0.22(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      '@opentelemetry/api': 1.9.0
+      '@planetscale/database': 1.19.0
+      '@prisma/client': 5.14.0(prisma@5.14.0)
+      '@tidbcloud/serverless': 0.1.1
+      '@types/better-sqlite3': 7.6.13
+      '@types/pg': 8.15.4
+      '@types/sql.js': 1.4.9
+      '@upstash/redis': 1.35.0
+      '@vercel/postgres': 0.8.0
+      '@xata.io/client': 0.29.5(typescript@5.6.3)
+      better-sqlite3: 11.9.1
+      bun-types: 0.6.14
+      expo-sqlite: 14.0.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))
+      gel: 2.1.0
+      knex: 2.5.1(better-sqlite3@11.9.1)(mysql2@3.14.1)(pg@8.16.0)(sqlite3@5.1.7)
+      kysely: 0.25.0
+      mysql2: 3.14.1
+      pg: 8.16.0
+      postgres: 3.4.7
+      prisma: 5.14.0
+      sql.js: 1.13.0
+      sqlite3: 5.1.7
+
   drizzle-prisma-generator@0.1.7:
     dependencies:
       '@prisma/generator-helper': 5.22.0
@@ -13130,6 +13275,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-asset@11.1.5(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
+    dependencies:
+      '@expo/image-utils': 0.7.4
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   expo-constants@17.1.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
     dependencies:
       '@expo/config': 11.0.10
@@ -13139,10 +13295,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@17.1.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
+    dependencies:
+      '@expo/config': 11.0.10
+      '@expo/env': 1.0.5
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   expo-file-system@18.1.10(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
     dependencies:
       expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+
+  expo-file-system@18.1.10(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)):
+    dependencies:
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
 
   expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
@@ -13150,10 +13322,23 @@ snapshots:
       fontfaceobserver: 2.3.0
       react: 18.3.1
 
+  expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
+    dependencies:
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      fontfaceobserver: 2.3.0
+      react: 18.3.1
+    optional: true
+
   expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
     dependencies:
       expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
       react: 18.3.1
+
+  expo-keep-awake@14.1.4(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
+    dependencies:
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+      react: 18.3.1
+    optional: true
 
   expo-modules-autolinking@2.1.10:
     dependencies:
@@ -13173,6 +13358,12 @@ snapshots:
     dependencies:
       '@expo/websql': 1.0.1
       expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+
+  expo-sqlite@14.0.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)):
+    dependencies:
+      '@expo/websql': 1.0.1
+      expo: 53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
 
   expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3):
     dependencies:
@@ -13202,6 +13393,36 @@ snapshots:
       - graphql
       - supports-color
       - utf-8-validate
+
+  expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3):
+    dependencies:
+      '@babel/runtime': 7.27.4
+      '@expo/cli': 0.24.13(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@expo/config': 11.0.10
+      '@expo/config-plugins': 10.0.2
+      '@expo/fingerprint': 0.12.4
+      '@expo/metro-config': 0.20.14
+      '@expo/vector-icons': 14.1.0(expo-font@13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      babel-preset-expo: 13.1.11(@babel/core@7.27.4)
+      expo-asset: 11.1.5(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      expo-constants: 17.1.6(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
+      expo-file-system: 18.1.10(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))
+      expo-font: 13.3.1(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      expo-keep-awake: 14.1.4(expo@53.0.9(@babel/core@7.27.4)(bufferutil@4.0.8)(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      expo-modules-autolinking: 2.1.10
+      expo-modules-core: 2.3.13
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+      react-native-edge-to-edge: 1.6.0(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      whatwg-url-without-unicode: 8.0.0-3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-react-compiler
+      - bufferutil
+      - graphql
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   exponential-backoff@3.1.2: {}
 
@@ -15384,6 +15605,12 @@ snapshots:
       react: 18.3.1
       react-native: 0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
 
+  react-native-edge-to-edge@1.6.0(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-native: 0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3)
+    optional: true
+
   react-native@0.79.2(@babel/core@7.27.4)(@types/react@18.3.23)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
@@ -15431,6 +15658,53 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3):
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@react-native/assets-registry': 0.79.2
+      '@react-native/codegen': 0.79.2(@babel/core@7.27.4)
+      '@react-native/community-cli-plugin': 0.79.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@react-native/gradle-plugin': 0.79.2
+      '@react-native/js-polyfills': 0.79.2
+      '@react-native/normalize-colors': 0.79.2
+      '@react-native/virtualized-lists': 0.79.2(react-native@0.79.2(@babel/core@7.27.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@6.0.3))(react@18.3.1)
+      abort-controller: 3.0.0
+      anser: 1.4.10
+      ansi-regex: 5.0.1
+      babel-jest: 29.7.0(@babel/core@7.27.4)
+      babel-plugin-syntax-hermes-parser: 0.25.1
+      base64-js: 1.5.1
+      chalk: 4.1.2
+      commander: 12.1.0
+      event-target-shim: 5.0.1
+      flow-enums-runtime: 0.0.6
+      glob: 7.2.3
+      invariant: 2.2.4
+      jest-environment-node: 29.7.0
+      memoize-one: 5.2.1
+      metro-runtime: 0.82.4
+      metro-source-map: 0.82.4
+      nullthrows: 1.1.1
+      pretty-format: 29.7.0
+      promise: 8.3.0
+      react: 18.3.1
+      react-devtools-core: 6.1.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      react-refresh: 0.14.2
+      regenerator-runtime: 0.13.11
+      scheduler: 0.25.0
+      semver: 7.7.2
+      stacktrace-parser: 0.1.11
+      whatwg-fetch: 3.6.20
+      ws: 6.2.3(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@react-native-community/cli'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    optional: true
 
   react-refresh@0.14.2: {}
 


### PR DESCRIPTION
# Why
Changes were required to improve the build, pack and publish workflow for the @team-drizzle/drizzle-kit package.

# What changed
- Moved development documentation from root README to drizzle-kit/README.md for better organization
- Updated package.json scripts for more reliable pack and publish commands
- Removed workspace dependency on drizzle-orm in favor of npm package version

# Test plan
- Build package locally using `pnpm build`
- Pack package using updated `npm run pack` command
- Publish package using updated `npm run publish` command
- Verify package can be installed from replit-internal npm registry
- Test package functionality in repl-it-web project