### PR TITLE
chore/add pg db types and exports 0.31.4

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.3",
+	"version": "0.31.4",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -50,12 +50,20 @@ export type DrizzleMySQLSnapshotJSON = MySQLSchemaKit;
 export type DrizzleSingleStoreSnapshotJSON = SingleStoreSchemaKit;
 
 // Replit
+export type DrizzlePostgresCredentials = PostgresCredentials;
+export type DrizzlePgDB = DB & {
+	proxy: Proxy;
+	migrate: (config: string | MigrationConfig) => Promise<void>;
+};
+export type DrizzlePgDBIntrospectSchema = Omit<
+	PgSchemaKit,
+	| 'internal'>;
 
 export const introspectPgDB = async (
-	db: DB,
+	db: DrizzlePgDB,
 	filters: string[],
 	schemaFilters: string[],
-) => {
+): Promise<DrizzlePgDBIntrospectSchema> => {
 	const matchers = filters.map((it) => {
 		return new Minimatch(it);
 	});
@@ -98,12 +106,9 @@ export const introspectPgDB = async (
 };
 
 export const preparePgDB = async (
-	credentials: PostgresCredentials,
+	credentials: DrizzlePostgresCredentials,
 ): Promise<
-	DB & {
-		proxy: Proxy;
-		migrate: (config: string | MigrationConfig) => Promise<void>;
-	}
+	DrizzlePgDB
 > => {
 	console.log(`Using 'pg' driver for database querying`);
 	const { default: pg } = await import('pg');
@@ -173,7 +178,7 @@ export const preparePgDB = async (
 };
 
 export const getPgClientPool = async (
-	targetCredentials: PostgresCredentials,
+	targetCredentials: DrizzlePostgresCredentials,
 ) => {
 	const { default: pg } = await import('pg');
 	const pool = 'url' in targetCredentials


### PR DESCRIPTION
# Why
Add type exports and improve type safety for PostgreSQL database operations in drizzle-kit.

# What changed
- Added new type exports for PostgreSQL credentials and database operations
- Created specific type interfaces for PostgreSQL database introspection
- Bumped drizzle-kit version from 0.31.3 to 0.31.4

# Test plan
- Verify exported types are properly accessible
- Test PostgreSQL database introspection with new type interfaces
- Ensure backward compatibility with existing PostgreSQL implementations