### PR TITLE
devprod/export types @0.31.8

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.7",
+	"version": "0.31.8",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -3,21 +3,21 @@ import { Minimatch } from 'minimatch';
 import {
 	columnsResolver,
 	enumsResolver,
-	indPolicyResolver, policyResolver,
+	indPolicyResolver,
+	policyResolver,
 	roleResolver,
 	schemasResolver,
-	sequencesResolver, tablesResolver,
-	viewsResolver
+	sequencesResolver,
+	tablesResolver,
+	viewsResolver,
 } from './cli/commands/migrate';
 import { pgSuggestions } from './cli/commands/pgPushUtils';
 import { PostgresCredentials } from './cli/validations/postgres';
 import { originUUID } from './global';
 import { MySqlSchema as MySQLSchemaKit } from './serializer/mysqlSchema';
-import { PgSchema as PgSchemaKit, pgSchema, squashPgScheme } from './serializer/pgSchema';
+import { PgSchema as PgSchemaKit, pgSchema, Role, squashPgScheme, View } from './serializer/pgSchema';
 import { fromDatabase } from './serializer/pgSerializer';
-import {
-	SingleStoreSchema as SingleStoreSchemaKit
-} from './serializer/singlestoreSchema';
+import { SingleStoreSchema as SingleStoreSchemaKit } from './serializer/singlestoreSchema';
 import { SQLiteSchema as SQLiteSchemaKit } from './serializer/sqliteSchema';
 import { ProxyParams } from './serializer/studio';
 import type { DB, Proxy } from './utils';
@@ -34,7 +34,8 @@ export type DrizzlePgDB = DB & {
 };
 export type DrizzlePgDBIntrospectSchema = Omit<
 	PgSchemaKit,
-	| 'internal'>;
+	'internal'
+>;
 
 export const introspectPgDB = async (
 	db: DrizzlePgDB,
@@ -166,6 +167,16 @@ export const getPgClientPool = async (
 };
 
 export { applyPgSnapshotsDiff } from './snapshotsDiffer';
+export type {
+	ColumnsResolverInput,
+	Enum,
+	PolicyResolverInput,
+	ResolverInput,
+	RolesResolverInput,
+	Sequence,
+	Table,
+	TablePolicyResolverInput,
+} from './snapshotsDiffer';
 export {
 	columnsResolver,
 	enumsResolver,
@@ -180,3 +191,4 @@ export {
 	tablesResolver,
 	viewsResolver,
 };
+export type { Role, View };


### PR DESCRIPTION
# Why
Export additional TypeScript types from the drizzle-kit package to improve developer experience and type safety.

# What changed
- Bumped drizzle-kit version from 0.31.7 to 0.31.8
- Added new type exports for PostgreSQL-related types (ColumnsResolverInput, Enum, PolicyResolverInput, etc.)
- Added exports for Role and View types

# Test plan
- Verify all newly exported types are accessible when importing from drizzle-kit
- Ensure existing functionality remains unchanged
- Test type compatibility in a project using drizzle-kit as a dependency