### PR TITLE
devprod/add select resolver pg suggestions

### DIFF
--- a/drizzle-kit/README.md
+++ b/drizzle-kit/README.md
@@ -13,7 +13,13 @@ Make any changes you require to the `drizzle-kit/api` file ([see here](./drizzle
 ```bash
 pnpm build
 ```
-This will build a `dist` file that you can import into `repl-it-web` using the `file:` protocol in `package.json` like so:
+This will build a `dist` file that you can import into `repl-it-web` using the `file:` by running:
+```bash
+cd pkg/pid2/
+
+pnpm add @drizzle-team/drizzle-kit@file:../../../drizzle-orm/drizzle-kit/dist
+```
+Which should add the following to `pkg/pid2/package.json`:
 ```
 "@drizzle-team/drizzle-kit": "file:../drizzle-orm/drizzle-kit/dist",
 ```

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.8",
+	"version": "0.31.9",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.31.9",
+	"version": "0.31.10",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -11,7 +11,7 @@ import {
 	tablesResolver,
 	viewsResolver,
 } from './cli/commands/migrate';
-import { pgSuggestions } from './cli/commands/pgPushUtils';
+import { pgSuggestions, SelectResolverInput, SelectResolverOutput } from './cli/commands/pgPushUtils';
 import { PostgresCredentials } from './cli/validations/postgres';
 import { originUUID } from './global';
 import { MySqlSchema as MySQLSchemaKit } from './serializer/mysqlSchema';
@@ -191,4 +191,4 @@ export {
 	tablesResolver,
 	viewsResolver,
 };
-export type { Role, View };
+export type { Role, SelectResolverInput, SelectResolverOutput, View };

--- a/drizzle-kit/src/api.ts
+++ b/drizzle-kit/src/api.ts
@@ -11,7 +11,7 @@ import {
 	tablesResolver,
 	viewsResolver,
 } from './cli/commands/migrate';
-import { pgSuggestions, SelectResolverInput, SelectResolverOutput } from './cli/commands/pgPushUtils';
+import { pgSuggestions } from './cli/commands/pgPushUtils';
 import { PostgresCredentials } from './cli/validations/postgres';
 import { originUUID } from './global';
 import { MySqlSchema as MySQLSchemaKit } from './serializer/mysqlSchema';
@@ -166,6 +166,7 @@ export const getPgClientPool = async (
 	return pool;
 };
 
+export type { SelectResolverInput, SelectResolverOutput } from './cli/commands/pgPushUtils';
 export { applyPgSnapshotsDiff } from './snapshotsDiffer';
 export type {
 	ColumnsResolverInput,
@@ -191,4 +192,4 @@ export {
 	tablesResolver,
 	viewsResolver,
 };
-export type { Role, SelectResolverInput, SelectResolverOutput, View };
+export type { Role, View };

--- a/drizzle-kit/src/cli/commands/migrate.ts
+++ b/drizzle-kit/src/cli/commands/migrate.ts
@@ -248,11 +248,7 @@ export const policyResolver = async (
 export const indPolicyResolver = async (
 	input: PolicyResolverInput<Policy>,
 ): Promise<PolicyResolverOutput<Policy>> => {
-	const result = await promptNamedConflict(
-		input.created,
-		input.deleted,
-		'policy',
-	);
+	const result = await promptNamedConflict(input.created, input.deleted, 'policy');
 	return {
 		created: result.created,
 		deleted: result.deleted,

--- a/drizzle-kit/src/cli/commands/pgPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/pgPushUtils.ts
@@ -56,7 +56,12 @@ function tableNameWithSchemaFrom(
 	return concatSchemaAndTableName(newSchemaName, newTableName);
 }
 
-type SelectResolverOutput = {
+export type SelectResolverInput = {
+	question: string;
+	items: string[];
+};
+
+export type SelectResolverOutput = {
 	data: {
 		index: number;
 		value: string;
@@ -68,7 +73,7 @@ export const pgSuggestions = async (
 	db: DB,
 	statements: JsonStatement[],
 	selectResolver?: (
-		items: string[],
+		input: SelectResolverInput,
 	) => Promise<SelectResolverOutput>,
 ) => {
 	let shouldAskForApprove = false;
@@ -251,12 +256,13 @@ export const pgSuggestions = async (
 					} table?\n`,
 				);
 
+				const question = `You're about to add ${unsquashedUnique.name} unique constraint to the table, which contains ${count} items. If this statement fails, you will receive an error from the database. Do you want to truncate ${statement.tableName} table?`;
 				const items = [
 					'No, add the constraint without truncating the table',
 					`Yes, truncate the table`,
 				];
 
-				const { status, data } = selectResolver ? await selectResolver(items) : await render(
+				const { status, data } = selectResolver ? await selectResolver({question, items}) : await render(
 					new Select(items),
 				);
 				if (data?.index === 1) {

--- a/drizzle-kit/src/cli/commands/pgPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/pgPushUtils.ts
@@ -57,7 +57,7 @@ function tableNameWithSchemaFrom(
 }
 
 export type SelectResolverInput = {
-	question: string;
+	name: string;
 	items: string[];
 };
 
@@ -255,13 +255,14 @@ export const pgSuggestions = async (
 					} table?\n`,
 				);
 
-				const question = `You're about to add ${unsquashedUnique.name} unique constraint to the table, which contains ${count} items. If this statement fails, you will receive an error from the database. Do you want to truncate ${statement.tableName} table?`;
+				const name =
+					`You're about to add ${unsquashedUnique.name} unique constraint to the table, which contains ${count} items. If this statement fails, you will receive an error from the database. Do you want to truncate ${statement.tableName} table?`;
 				const items = [
 					'No, add the constraint without truncating the table',
 					`Yes, truncate the table`,
 				];
 
-				const { data } = selectResolver ? await selectResolver({question, items}) : await render(
+				const { data } = selectResolver ? await selectResolver({ name, items }) : await render(
 					new Select(items),
 				);
 				if (data?.index === 1) {

--- a/drizzle-kit/src/cli/commands/pgPushUtils.ts
+++ b/drizzle-kit/src/cli/commands/pgPushUtils.ts
@@ -66,7 +66,6 @@ export type SelectResolverOutput = {
 		index: number;
 		value: string;
 	};
-	status: 'submitted';
 };
 
 export const pgSuggestions = async (
@@ -262,7 +261,7 @@ export const pgSuggestions = async (
 					`Yes, truncate the table`,
 				];
 
-				const { status, data } = selectResolver ? await selectResolver({question, items}) : await render(
+				const { data } = selectResolver ? await selectResolver({question, items}) : await render(
 					new Select(items),
 				);
 				if (data?.index === 1) {


### PR DESCRIPTION
# Why
To enable custom selection resolver functionality in pgSuggestions, allowing for more flexible handling of table truncation decisions during PostgreSQL operations.

# What changed
- Added optional `selectResolver` parameter to `pgSuggestions` function
- Implemented conditional logic to use either custom resolver or default render method
- Updated version from 0.31.8 to 0.31.9

# Test plan
- Test pgSuggestions with custom selectResolver
- Verify default behavior remains unchanged when no selectResolver is provided
- Ensure correct handling of table truncation decisions with both resolver methods
- Validate response format matches SelectResolverOutput type