### PR TITLE
Make PostgreSQL foreign key drops idempotent

### DIFF
--- a/changelogs/drizzle-kit/0.32.3.md
+++ b/changelogs/drizzle-kit/0.32.3.md
@@ -1,0 +1,3 @@
+### PostgreSQL bug fix
+
+Foreign-key removals now use `DROP CONSTRAINT IF EXISTS`. This prevents generated migrations from failing when an earlier `DROP TABLE ... CASCADE` already removed the same constraint.

--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@drizzle-team/drizzle-kit",
-	"version": "0.32.1",
+	"version": "0.32.3",
 	"homepage": "https://orm.drizzle.team",
 	"keywords": [
 		"drizzle",

--- a/drizzle-kit/src/sqlgenerator.ts
+++ b/drizzle-kit/src/sqlgenerator.ts
@@ -3476,7 +3476,7 @@ class PgDeleteForeignKeyConvertor extends Convertor {
 			? `"${statement.schema}"."${tableFrom}"`
 			: `"${tableFrom}"`;
 
-		return `ALTER TABLE ${tableNameWithSchema} DROP CONSTRAINT "${name}";\n`;
+		return `ALTER TABLE ${tableNameWithSchema} DROP CONSTRAINT IF EXISTS "${name}";\n`;
 	}
 }
 

--- a/drizzle-kit/tests/pg-tables.test.ts
+++ b/drizzle-kit/tests/pg-tables.test.ts
@@ -753,6 +753,28 @@ test('alter composite primary key', async () => {
 	]);
 });
 
+test('drop foreign key constraint idempotently', async () => {
+	const users = pgTable('users', {
+		id: integer('id').primaryKey(),
+	});
+	const postsFrom = pgTable('posts', {
+		userId: integer('user_id').references(() => users.id),
+	});
+	const postsTo = pgTable('posts', {
+		userId: integer('user_id'),
+	});
+
+	const { sqlStatements } = await diffTestSchemas(
+		{ users, posts: postsFrom },
+		{ users, posts: postsTo },
+		[],
+	);
+
+	expect(sqlStatements).toStrictEqual([
+		'ALTER TABLE "posts" DROP CONSTRAINT IF EXISTS "posts_user_id_users_id_fk";\n',
+	]);
+});
+
 test('add index with op', async () => {
 	const from = {
 		users: pgTable('users', {


### PR DESCRIPTION
<!-- BEGIN: CONTEXT -->

### TLDR

Makes generated PostgreSQL foreign-key removals idempotent so database publishing does not fail when a cascading table drop already removed the constraint.

<!-- END: HUMAN ONLY -->
<!-- END: CONTEXT -->

---

### Why

Drizzle can generate `DROP TABLE ... CASCADE` followed by an explicit foreign-key removal. PostgreSQL removes the foreign key during the cascade, so the subsequent `DROP CONSTRAINT` fails even though the database has reached the intended state.

### What changed

PostgreSQL `delete_reference` statements now render as `DROP CONSTRAINT IF EXISTS`. This fixes the behavior in the SQL generator rather than rewriting rendered SQL in pid2.

Added schema-diff regression coverage for removing a foreign key.

### Validations performed

- PostgreSQL table schema-diff suite: 30 tests passed
- Drizzle Kit TypeScript check passed
- dprint formatting check passed

<h2></h2> <!-- Separator line - keep unmodified -->

### If this breaks

Generated PostgreSQL migrations may behave differently when removing foreign-key constraints.

### Rollout and rollback

Rolls out in the next `@drizzle-team/drizzle-kit` release. Safe to revert; reverting restores strict failure when a generated foreign-key removal targets an already-absent constraint.

~ written by Zerg :space_invader: ([lurking-cyclone-5507](https://zerg.zergrush.dev/chat?id=lurking-cyclone-5507))