### PR TITLE
Add Replit compatibility to Drizzle Kit RC4

### DIFF
--- a/drizzle-kit/package.json
+++ b/drizzle-kit/package.json
@@ -47,7 +47,9 @@
 		"build:ext": "rm -rf ./dist && vitest run bin.test && vitest run ./tests/postgres/ && vitest run ./tests/sqlite && vitest run ./tests/mysql && tsx build.ext.ts",
 		"pack": "cp package.json README.md dist/ && (cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
 		"pack:artifact": "pnpm run pack",
+		"pack:replit": "pnpm run build && tsx scripts/prepare-replit-package.ts && (cd dist && npm pack --pack-destination ..) && rm -f package.tgz && mv *.tgz package.tgz",
 		"publish": "npm publish package.tgz",
+		"publish:replit": "pnpm run pack:replit && npm publish package.tgz --provenance=false",
 		"test:postgres": "vitest run ./postgres/",
 		"test:other": "vitest run ./mysql/ ./sqlite/ ./other",
 		"test:cockroach": "vitest run ./cockroach",
@@ -140,6 +142,18 @@
 			},
 			"types": "./index.d.mts",
 			"default": "./index.mjs"
+		},
+		"./api": {
+			"import": {
+				"types": "./api.d.mts",
+				"default": "./api.mjs"
+			},
+			"require": {
+				"types": "./api.d.ts",
+				"default": "./api.js"
+			},
+			"types": "./api.d.mts",
+			"default": "./api.mjs"
 		},
 		"./api-postgres": {
 			"import": {

--- a/drizzle-kit/scripts/build.ts
+++ b/drizzle-kit/scripts/build.ts
@@ -115,6 +115,7 @@ async function buildDeclarations() {
 
 	await tsdown({
 		entry: {
+			api: './src/ext/api.ts',
 			'api-postgres': './src/ext/api-postgres.ts',
 			'api-mysql': './src/ext/api-mysql.ts',
 			'api-sqlite': './src/ext/api-sqlite.ts',
@@ -152,6 +153,7 @@ async function copyDeclarationsAndCleanTemp() {
 
 async function postProcessApiFiles() {
 	const apiFiles = [
+		'dist/api.js',
 		'dist/api-postgres.js',
 		'dist/api-mysql.js',
 		'dist/api-sqlite.js',
@@ -186,6 +188,18 @@ async function main() {
 			name: 'index-esm',
 			input: './src/index.ts',
 			outputName: 'index.mjs',
+			format: 'esm',
+		}),
+		buildBundle({
+			name: 'api-cjs',
+			input: './src/ext/api.ts',
+			outputName: 'api.js',
+			format: 'cjs',
+		}),
+		buildBundle({
+			name: 'api-esm',
+			input: './src/ext/api.ts',
+			outputName: 'api.mjs',
 			format: 'esm',
 		}),
 		buildBundle({

--- a/drizzle-kit/scripts/prepare-replit-package.ts
+++ b/drizzle-kit/scripts/prepare-replit-package.ts
@@ -4,13 +4,25 @@ async function main() {
 	const packagePath = 'dist/package.json';
 	const parsed: unknown = JSON.parse(await readFile(packagePath, 'utf8'));
 
-	if (typeof parsed !== 'object' || parsed === null || !('name' in parsed) || parsed.name !== 'drizzle-kit') {
+	if (
+		typeof parsed !== 'object'
+		|| parsed === null
+		|| !('name' in parsed)
+		|| parsed.name !== 'drizzle-kit'
+		|| !('dependencies' in parsed)
+		|| typeof parsed.dependencies !== 'object'
+		|| parsed.dependencies === null
+		|| !('@drizzle-team/brocli' in parsed.dependencies)
+	) {
 		throw new Error('Expected the built drizzle-kit package manifest');
 	}
+	const dependencies = Object.fromEntries(
+		Object.entries(parsed.dependencies).filter(([name]) => name !== '@drizzle-team/brocli'),
+	);
 
 	await writeFile(
 		packagePath,
-		`${JSON.stringify({ ...parsed, name: '@drizzle-team/drizzle-kit' }, null, '\t')}\n`,
+		`${JSON.stringify({ ...parsed, name: '@drizzle-team/drizzle-kit', dependencies }, null, '\t')}\n`,
 	);
 }
 

--- a/drizzle-kit/scripts/prepare-replit-package.ts
+++ b/drizzle-kit/scripts/prepare-replit-package.ts
@@ -1,0 +1,20 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+async function main() {
+	const packagePath = 'dist/package.json';
+	const parsed: unknown = JSON.parse(await readFile(packagePath, 'utf8'));
+
+	if (typeof parsed !== 'object' || parsed === null || !('name' in parsed) || parsed.name !== 'drizzle-kit') {
+		throw new Error('Expected the built drizzle-kit package manifest');
+	}
+
+	await writeFile(
+		packagePath,
+		`${JSON.stringify({ ...parsed, name: '@drizzle-team/drizzle-kit' }, null, '\t')}\n`,
+	);
+}
+
+main().catch((error: unknown) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/drizzle-kit/src/ext/api.ts
+++ b/drizzle-kit/src/ext/api.ts
@@ -1,345 +1,475 @@
-// import { LibSQLDatabase } from 'drizzle-orm/libsql';
-// import type { MySql2Database } from 'drizzle-orm/mysql2';
-// import { PgDatabase } from 'drizzle-orm/pg-core';
-// import { SingleStoreDriverDatabase } from 'drizzle-orm/singlestore';
-// import { introspect as postgresIntrospect } from '../cli/commands/pull-postgres';
-// import { sqliteIntrospect } from '../cli/commands/pull-sqlite';
-// import { suggestions } from '../cli/commands/push-postgres';
-// import { updateUpToV6 as upPgV6, updateUpToV7 as upPgV7 } from '../cli/commands/up-postgres';
-// import { resolver } from '../cli/prompts';
-// import type { CasingType } from '../cli/validations/common';
-// import { ProgressView, schemaError, schemaWarning } from '../cli/views';
-// import { fromDrizzleSchema, fromExports } from '../dialects/postgres/drizzle';
-// import { PostgresSnapshot, toJsonSnapshot } from '../dialects/postgres/snapshot';
-// import type { Config } from '../index';
-// import { originUUID } from '../utils';
-// import type { DB, SQLiteDB } from '../utils';
-// import { getTablesFilterByExtensions } from './extensions/getTablesFilterByExtensions';
+import type { MigrationConfig } from 'drizzle-orm/migrator';
+import type { Pool, PoolClient, QueryConfig } from 'pg';
+import type { Resolver } from '../dialects/common';
+import { fromJson } from '../dialects/postgres/convertor';
+import type {
+	CheckConstraint,
+	Column,
+	Enum,
+	ForeignKey,
+	Index,
+	InterimSchema,
+	Policy,
+	PostgresDDL,
+	PostgresEntities,
+	PrimaryKey,
+	Privilege,
+	Role,
+	Schema,
+	Sequence,
+	UniqueConstraint,
+	View,
+} from '../dialects/postgres/ddl';
+import { interimToDDL } from '../dialects/postgres/ddl';
+import { ddlDiff } from '../dialects/postgres/diff';
+import { fromDatabaseForDrizzle } from '../dialects/postgres/introspect';
+import type { JsonStatement } from '../dialects/postgres/statements';
+import { prepareEntityFilter } from '../dialects/pull-utils';
+import '../@types/utils';
 
-// import * as postgres from './api-postgres';
+type Queryable = Pool | PoolClient;
+type Named = { name: string; schema?: string; table?: string };
+type RenamePromptItem<T extends Named> = { from: T; to: T };
+type QueryDB = {
+	query: <T extends any = any>(sql: string, params?: any[]) => Promise<T[]>;
+};
+type ProxyParams = {
+	sql: string;
+	params?: any[];
+	mode: 'array' | 'object';
+	method: 'values' | 'get' | 'all' | 'run' | 'execute';
+};
 
-// SQLite
+export type DrizzlePgDB = QueryDB & {
+	proxy: (params: ProxyParams) => Promise<any[]>;
+	migrate: (config: string | MigrationConfig) => Promise<void>;
+};
 
-// TODO commented this because of build error
-// export const generateSQLiteDrizzleJson = async (
-// 	imports: Record<string, unknown>,
-// 	prevId?: string,
-// 	casing?: CasingType,
-// ): Promise<SQLiteSchemaKit> => {
-// 	const { prepareFromExports } = await import('./dialects/sqlite/imports');
+export type PreparePgDBOptions = {
+	queryConcurrency?: number;
+};
 
-// 	const prepared = prepareFromExports(imports);
+export type DrizzlePgDBIntrospectSchema = InterimSchema;
 
-// 	const id = randomUUID();
+export type LegacyResolverInput<T extends Named> = {
+	created: T[];
+	deleted: T[];
+	schema?: string;
+	tableName?: string;
+};
 
-// 	const snapshot = fromDrizzleSchema(prepared.tables, prepared.views, casing);
+export type LegacyResolverOutput<T extends Named> = {
+	created: T[];
+	deleted: T[];
+	renamed?: RenamePromptItem<T>[];
+	renamedOrMoved?: RenamePromptItem<T>[];
+	moved?: { name: string; schemaFrom: string; schemaTo: string }[];
+};
 
-// 	return {
-// 		...snapshot,
-// 		id,
-// 		prevId: prevId ?? originUUID,
-// 	};
-// };
+export type LegacyResolver<T extends Named> = (
+	input: LegacyResolverInput<T>,
+) => Promise<LegacyResolverOutput<T>>;
 
-// export const generateSQLiteMigration = async (
-// 	prev: DrizzleSQLiteSnapshotJSON,
-// 	cur: DrizzleSQLiteSnapshotJSON,
-// ) => {
-// 	const { applySqliteSnapshotsDiff } = await import('./dialects/sqlite/diff');
+const defaultMigrationsConfig = {
+	schema: 'drizzle',
+	table: '__drizzle_migrations',
+};
 
-// 	const validatedPrev = sqliteSchema.parse(prev);
-// 	const validatedCur = sqliteSchema.parse(cur);
+const passthroughResolver = async <T extends Named>({ created, deleted }: LegacyResolverInput<T>) => {
+	return { created, deleted, renamed: [] };
+};
 
-// 	const squashedPrev = squashSqliteScheme(validatedPrev);
-// 	const squashedCur = squashSqliteScheme(validatedCur);
+export const schemasResolver: LegacyResolver<Schema> = passthroughResolver;
+export const enumsResolver: LegacyResolver<Enum> = passthroughResolver;
+export const sequencesResolver: LegacyResolver<Sequence> = passthroughResolver;
+export const policyResolver: LegacyResolver<Policy> = passthroughResolver;
+export const indPolicyResolver: LegacyResolver<Policy> = passthroughResolver;
+export const roleResolver: LegacyResolver<Role> = passthroughResolver;
+export const tablesResolver: LegacyResolver<PostgresEntities['tables']> = passthroughResolver;
+export const columnsResolver: LegacyResolver<Column> = passthroughResolver;
+export const viewsResolver: LegacyResolver<View> = passthroughResolver;
 
-// 	const { sqlStatements } = await applySqliteSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		sqliteViewsResolver,
-// 		validatedPrev,
-// 		validatedCur,
-// 	);
+export type ResolverInput<T extends Named = Named> = LegacyResolverInput<T>;
+export type ColumnsResolverInput = LegacyResolverInput<Column>;
+export type PolicyResolverInput = LegacyResolverInput<Policy>;
+export type TablePolicyResolverInput = LegacyResolverInput<Policy>;
+export type RolesResolverInput = LegacyResolverInput<Role>;
+export type { Enum, Role, Sequence, View };
+export type Table = PostgresEntities['tables'];
 
-// 	return sqlStatements;
-// };
+export type SelectResolverInput = {
+	entity: {
+		type: 'createUniqueConstraint';
+		name: string;
+		count: number;
+		tableName: string;
+	};
+	items: string[];
+};
 
-// export const pushSQLiteSchema = async (
-// 	imports: Record<string, unknown>,
-// 	drizzleInstance: LibSQLDatabase<any>,
-// ) => {
-// 	const { applySqliteSnapshotsDiff } = await import('./dialects/sqlite/diff');
-// 	const { sql } = await import('drizzle-orm');
+export type SelectResolverOutput = {
+	data: {
+		index: number;
+		value: string;
+	};
+};
 
-// 	const db: SQLiteDB = {
-// 		query: async (query: string, params?: any[]) => {
-// 			const res = drizzleInstance.all<any>(sql.raw(query));
-// 			return res;
-// 		},
-// 		run: async (query: string) => {
-// 			return Promise.resolve(drizzleInstance.run(sql.raw(query))).then(
-// 				() => {},
-// 			);
-// 		},
-// 	};
+type SelectResolver = (input: SelectResolverInput) => Promise<SelectResolverOutput>;
 
-// 	const cur = await generateSQLiteDrizzleJson(imports);
-// 	const progress = new ProgressView(
-// 		'Pulling schema from database...',
-// 		'Pulling schema from database...',
-// 	);
+function createConcurrencyLimiter(concurrency?: number) {
+	if (concurrency === undefined) {
+		return <T>(run: () => Promise<T>) => run();
+	}
 
-// 	const { schema: prev } = await sqliteIntrospect(db, [], progress);
+	if (!Number.isInteger(concurrency) || concurrency < 1) {
+		throw new RangeError('queryConcurrency must be a positive integer');
+	}
 
-// 	const validatedPrev = sqliteSchema.parse(prev);
-// 	const validatedCur = sqliteSchema.parse(cur);
+	let activeCount = 0;
+	const queue: Array<() => void> = [];
 
-// 	const squashedPrev = squashSqliteScheme(validatedPrev, 'push');
-// 	const squashedCur = squashSqliteScheme(validatedCur, 'push');
+	const runNext = () => {
+		if (activeCount >= concurrency) return;
 
-// 	const { statements, _meta } = await applySqliteSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		sqliteViewsResolver,
-// 		validatedPrev,
-// 		validatedCur,
-// 		'push',
-// 	);
+		const next = queue.shift();
+		if (!next) return;
 
-// 	const { shouldAskForApprove, statementsToExecute, infoToPrint } = await logSuggestionsAndReturn(
-// 		db,
-// 		statements,
-// 		squashedPrev,
-// 		squashedCur,
-// 		_meta!,
-// 	);
+		activeCount += 1;
+		next();
+	};
 
-// 	return {
-// 		hasDataLoss: shouldAskForApprove,
-// 		warnings: infoToPrint,
-// 		statementsToExecute,
-// 		apply: async () => {
-// 			for (const dStmnt of statementsToExecute) {
-// 				await db.query(dStmnt);
-// 			}
-// 		},
-// 	};
-// };
+	return <T>(run: () => Promise<T>) => {
+		return new Promise<T>((resolve, reject) => {
+			queue.push(() => {
+				Promise.resolve()
+					.then(run)
+					.then(resolve, reject)
+					.finally(() => {
+						activeCount -= 1;
+						runNext();
+					});
+			});
 
-// MySQL
-// TODO commented this because of build error
-// export const generateMySQLDrizzleJson = async (
-// 	imports: Record<string, unknown>,
-// 	prevId?: string,
-// 	casing?: CasingType,
-// ): Promise<MySQLSchemaKit> => {
-// 	const { prepareFromExports } = await import('./serializer/mysqlImports');
+			runNext();
+		});
+	};
+}
 
-// 	const prepared = prepareFromExports(imports);
+export const preparePgDB = async (
+	pool: Queryable,
+	options: PreparePgDBOptions = {},
+): Promise<DrizzlePgDB> => {
+	const { default: pg } = await import('pg');
+	const { drizzle } = await import('drizzle-orm/node-postgres');
+	const { migrate } = await import('drizzle-orm/node-postgres/migrator');
 
-// 	const id = randomUUID();
+	const getTypeParser: typeof pg.types.getTypeParser = (typeId, format) => {
+		if (
+			typeId === pg.types.builtins.TIMESTAMPTZ
+			|| typeId === pg.types.builtins.TIMESTAMP
+			|| typeId === pg.types.builtins.DATE
+			|| typeId === pg.types.builtins.INTERVAL
+		) {
+			return (value: string) => value;
+		}
 
-// 	const snapshot = generateMySqlSnapshot(prepared.tables, prepared.views, casing);
+		return pg.types.getTypeParser(typeId, format);
+	};
 
-// 	return {
-// 		...snapshot,
-// 		id,
-// 		prevId: prevId ?? originUUID,
-// 	};
-// };
+	const limitQuery = createConcurrencyLimiter(options.queryConcurrency);
+	const types = { getTypeParser };
 
-// export const generateMySQLMigration = async (
-// 	prev: DrizzleMySQLSnapshotJSON,
-// 	cur: DrizzleMySQLSnapshotJSON,
-// ) => {
-// 	const { ddlDiff: applyMysqlSnapshotsDiff } = await import('./dialects/mysql/mysql');
+	const query: QueryDB['query'] = async (sql, params) => {
+		const config: QueryConfig = {
+			text: sql,
+			values: params ?? [],
+			types,
+		};
+		const result = await limitQuery(() => pool.query(config));
+		return result.rows;
+	};
 
-// 	const validatedPrev = mysqlSchema.parse(prev);
-// 	const validatedCur = mysqlSchema.parse(cur);
+	const proxy: DrizzlePgDB['proxy'] = async (params) => {
+		const config: QueryConfig = {
+			text: params.sql,
+			values: params.params,
+			...(params.mode === 'array' && { rowMode: 'array' }),
+			types,
+		};
+		const result = await limitQuery(() => pool.query(config));
+		return result.rows;
+	};
 
-// 	const squashedPrev = squashMysqlScheme(validatedPrev);
-// 	const squashedCur = squashMysqlScheme(validatedCur);
+	const migrateFn = async (config: string | MigrationConfig) => {
+		const db = drizzle({ client: pool });
+		await migrate(db, config as MigrationConfig);
+	};
 
-// 	const { sqlStatements } = await applyMysqlSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		mySqlViewsResolver,
-// 		uniqueResolver,
-// 		validatedPrev,
-// 		validatedCur,
-// 	);
+	return { query, proxy, migrate: migrateFn };
+};
 
-// 	return sqlStatements;
-// };
+export const createEmptyPgSchema = (): DrizzlePgDBIntrospectSchema => ({
+	schemas: [],
+	enums: [],
+	tables: [],
+	columns: [],
+	indexes: [],
+	pks: [],
+	fks: [],
+	uniques: [],
+	checks: [],
+	sequences: [],
+	roles: [],
+	privileges: [],
+	policies: [],
+	views: [],
+	viewColumns: [],
+});
 
-// export const pushMySQLSchema = async (
-// 	imports: Record<string, unknown>,
-// 	drizzleInstance: MySql2Database<any>,
-// 	databaseName: string,
-// ) => {
-// 	const { ddlDiff: applyMysqlSnapshotsDiff } = await import('./dialects/mysql/mysql');
-// 	const { logSuggestionsAndReturn } = await import(
-// 		'./cli/commands/mysqlPushUtils'
-// 	);
-// 	const { mysqlPushIntrospect } = await import(
-// 		'./cli/commands/pull-mysql'
-// 	);
-// 	const { sql } = await import('drizzle-orm');
+export const introspectPgDB = async (
+	db: DrizzlePgDB,
+	filters: string[],
+	schemaFilters: string[],
+): Promise<DrizzlePgDBIntrospectSchema> => {
+	const filter = prepareEntityFilter('postgresql', {
+		tables: filters,
+		schemas: schemaFilters,
+		entities: undefined,
+		extensions: [],
+	}, []);
 
-// 	const db: DB = {
-// 		query: async (query: string, params?: any[]) => {
-// 			const res = await drizzleInstance.execute(sql.raw(query));
-// 			return res[0] as unknown as any[];
-// 		},
-// 	};
-// 	const cur = await generateMySQLDrizzleJson(imports);
-// 	const { schema: prev } = await mysqlPushIntrospect(db, databaseName, []);
+	return fromDatabaseForDrizzle(db, filter, () => {}, defaultMigrationsConfig);
+};
 
-// 	const validatedPrev = mysqlSchema.parse(prev);
-// 	const validatedCur = mysqlSchema.parse(cur);
+function isDDL(schema: DrizzlePgDBIntrospectSchema | PostgresDDL): schema is PostgresDDL {
+	return 'entities' in schema;
+}
 
-// 	const squashedPrev = squashMysqlScheme(validatedPrev);
-// 	const squashedCur = squashMysqlScheme(validatedCur);
+export const pgSchema = {
+	parse: (schema: DrizzlePgDBIntrospectSchema) => schema,
+};
 
-// 	const { statements } = await applyMysqlSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		mySqlViewsResolver,
-// 		uniqueResolver,
-// 		validatedPrev,
-// 		validatedCur,
-// 		'push',
-// 	);
+export const squashPgScheme = (
+	schema: DrizzlePgDBIntrospectSchema | PostgresDDL,
+	_mode?: 'default' | 'push',
+): PostgresDDL => {
+	if (isDDL(schema)) return schema;
 
-// 	const { shouldAskForApprove, statementsToExecute, infoToPrint } = await logSuggestionsAndReturn(
-// 		db,
-// 		statements,
-// 		validatedCur,
-// 	);
+	const { ddl, errors } = interimToDDL(schema);
+	if (errors.length > 0) {
+		throw new Error(`Failed to convert Postgres schema: ${JSON.stringify(errors)}`);
+	}
 
-// 	return {
-// 		hasDataLoss: shouldAskForApprove,
-// 		warnings: infoToPrint,
-// 		statementsToExecute,
-// 		apply: async () => {
-// 			for (const dStmnt of statementsToExecute) {
-// 				await db.query(dStmnt);
-// 			}
-// 		},
-// 	};
-// };
+	return ddl;
+};
 
-// SingleStore
-// TODO commented this because of build error
-// export const generateSingleStoreDrizzleJson = async (
-// 	imports: Record<string, unknown>,
-// 	prevId?: string,
-// 	casing?: CasingType,
-// ): Promise<SingleStoreSchemaKit> => {
-// 	const { prepareFromExports } = await import('./serializer/singlestoreImports');
+function movedToRenamed<T extends Named>(
+	moved: { name: string; schemaFrom: string; schemaTo: string },
+	created: T[],
+	deleted: T[],
+): RenamePromptItem<T> {
+	const from = deleted.find((item) => item.name === moved.name && (item.schema ?? 'public') === moved.schemaFrom);
+	const to = created.find((item) => item.name === moved.name && (item.schema ?? 'public') === moved.schemaTo);
+	if (!from || !to) {
+		throw new Error(`Invalid move for ${moved.name}: ${moved.schemaFrom} -> ${moved.schemaTo}`);
+	}
 
-// 	const prepared = prepareFromExports(imports);
+	return { from, to };
+}
 
-// 	const id = randomUUID();
+function adaptResolver<T extends Named>(resolver: LegacyResolver<T>): Resolver<T> {
+	return async ({ created, deleted }) => {
+		const sample = created[0] ?? deleted[0];
+		const result = await resolver({
+			created,
+			deleted,
+			schema: sample?.schema,
+			tableName: sample?.table,
+		});
 
-// 	const snapshot = generateSingleStoreSnapshot(prepared.tables, /* prepared.views, */ casing);
+		return {
+			created: result.created,
+			deleted: result.deleted,
+			renamedOrMoved: [
+				...(result.renamed ?? []),
+				...(result.renamedOrMoved ?? []),
+				...(result.moved ?? []).map((move) => movedToRenamed(move, created, deleted)),
+			],
+		};
+	};
+}
 
-// 	return {
-// 		...snapshot,
-// 		id,
-// 		prevId: prevId ?? originUUID,
-// 	};
-// };
+const noOpV1Resolver = async <T extends Named>({ created, deleted }: LegacyResolverInput<T>) => {
+	return { created, deleted, renamedOrMoved: [] };
+};
 
-// export const generateSingleStoreMigration = async (
-// 	prev: DrizzleSingleStoreSnapshotJSON,
-// 	cur: DrizzleSingleStoreSnapshotJSON,
-// ) => {
-// 	const { applySingleStoreSnapshotsDiff } = await import('./snapshot-differ/singlestore');
+export const applyPgSnapshotsDiff = async (
+	targetSchema: PostgresDDL,
+	sourceSchema: PostgresDDL,
+	schemasResolverArg: LegacyResolver<Schema>,
+	enumsResolverArg: LegacyResolver<Enum>,
+	sequencesResolverArg: LegacyResolver<Sequence>,
+	policyResolverArg: LegacyResolver<Policy>,
+	_indPolicyResolverArg: LegacyResolver<Policy>,
+	roleResolverArg: LegacyResolver<Role>,
+	tablesResolverArg: LegacyResolver<PostgresEntities['tables']>,
+	columnsResolverArg: LegacyResolver<Column>,
+	viewsResolverArg: LegacyResolver<View>,
+	_validatedTarget: DrizzlePgDBIntrospectSchema,
+	_validatedSource: DrizzlePgDBIntrospectSchema,
+	mode: 'default' | 'push',
+) => {
+	return ddlDiff(
+		targetSchema,
+		sourceSchema,
+		adaptResolver(schemasResolverArg),
+		adaptResolver(enumsResolverArg),
+		adaptResolver(sequencesResolverArg),
+		adaptResolver(policyResolverArg),
+		adaptResolver(roleResolverArg),
+		noOpV1Resolver<Privilege>,
+		adaptResolver(tablesResolverArg),
+		adaptResolver(columnsResolverArg),
+		adaptResolver(viewsResolverArg),
+		noOpV1Resolver<UniqueConstraint>,
+		noOpV1Resolver<Index>,
+		noOpV1Resolver<CheckConstraint>,
+		noOpV1Resolver<PrimaryKey>,
+		noOpV1Resolver<ForeignKey>,
+		mode,
+	);
+};
 
-// 	const validatedPrev = singlestoreSchema.parse(prev);
-// 	const validatedCur = singlestoreSchema.parse(cur);
+function quoteIdentifier(value: string) {
+	return `"${value.replaceAll('"', '""')}"`;
+}
 
-// 	const squashedPrev = squashSingleStoreScheme(validatedPrev);
-// 	const squashedCur = squashSingleStoreScheme(validatedCur);
+function quotedTable(schema: string | undefined, table: string) {
+	return schema && schema !== 'public'
+		? `${quoteIdentifier(schema)}.${quoteIdentifier(table)}`
+		: quoteIdentifier(table);
+}
 
-// 	const { sqlStatements } = await applySingleStoreSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		/* singleStoreViewsResolver, */
-// 		validatedPrev,
-// 		validatedCur,
-// 		'push',
-// 	);
+async function countRows(db: QueryDB, schema: string | undefined, table: string) {
+	const rows = await db.query<{ count: string | number }>(
+		`select count(*) as count from ${quotedTable(schema, table)}`,
+	);
+	return Number(rows[0]?.count ?? 0);
+}
 
-// 	return sqlStatements;
-// };
+export const pgSuggestions = async (
+	db: QueryDB,
+	statements: JsonStatement[],
+	selectResolver?: SelectResolver,
+) => {
+	let shouldAskForApprove = false;
+	const statementsToExecute: string[] = [];
+	const infoToPrint: string[] = [];
+	const matViewsToRemove: string[] = [];
+	const columnsToRemove: string[] = [];
+	const schemasToRemove: string[] = [];
+	const tablesToTruncate: string[] = [];
+	const tablesToRemove: string[] = [];
 
-// export const pushSingleStoreSchema = async (
-// 	imports: Record<string, unknown>,
-// 	drizzleInstance: SingleStoreDriverDatabase<any>,
-// 	databaseName: string,
-// ) => {
-// 	const { applySingleStoreSnapshotsDiff } = await import('./snapshot-differ/singlestore');
-// 	const { logSuggestionsAndReturn } = await import(
-// 		'./cli/commands/singlestorePushUtils'
-// 	);
-// 	const { singlestorePushIntrospect } = await import(
-// 		'./cli/commands/pull-singlestore'
-// 	);
-// 	const { sql } = await import('drizzle-orm');
+	for (const statement of statements) {
+		if (statement.type === 'drop_table') {
+			const count = await countRows(db, statement.table.schema, statement.table.name);
+			if (count > 0) {
+				infoToPrint.push(`You're about to delete ${statement.table.name} table with ${count} items`);
+				tablesToRemove.push(statement.table.name);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'drop_view' && statement.view.materialized) {
+			const count = await countRows(db, statement.view.schema, statement.view.name);
+			if (count > 0) {
+				infoToPrint.push(`You're about to delete ${statement.view.name} materialized view with ${count} items`);
+				matViewsToRemove.push(statement.view.name);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'drop_column') {
+			const count = await countRows(db, statement.column.schema, statement.column.table);
+			if (count > 0) {
+				infoToPrint.push(
+					`You're about to delete ${statement.column.name} column in ${statement.column.table} table with ${count} items`,
+				);
+				columnsToRemove.push(`${statement.column.table}_${statement.column.name}`);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'drop_schema') {
+			const escapedSchema = statement.name.replaceAll("'", "''");
+			const rows = await db.query<{ count: string | number }>(
+				`select count(*) as count from information_schema.tables where table_schema = '${escapedSchema}';`,
+			);
+			const count = Number(rows[0]?.count ?? 0);
+			if (count > 0) {
+				infoToPrint.push(`You're about to delete ${statement.name} schema with ${count} tables`);
+				schemasToRemove.push(statement.name);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'alter_column' && statement.diff.type) {
+			const count = await countRows(db, statement.to.schema, statement.to.table);
+			if (count > 0) {
+				infoToPrint.push(`You're about to change ${statement.to.name} column type with ${count} items`);
+				statementsToExecute.push(`truncate table ${quotedTable(statement.to.schema, statement.to.table)} cascade;`);
+				tablesToTruncate.push(statement.to.table);
+				shouldAskForApprove = true;
+			}
+		} else if (
+			statement.type === 'add_column'
+			&& statement.column.notNull
+			&& (statement.column.default === null || statement.column.default === undefined)
+		) {
+			const count = await countRows(db, statement.column.schema, statement.column.table);
+			if (count > 0) {
+				infoToPrint.push(
+					`You're about to add not-null ${statement.column.name} column without a default to a table with ${count} items`,
+				);
+				statementsToExecute.push(
+					`truncate table ${quotedTable(statement.column.schema, statement.column.table)} cascade;`,
+				);
+				tablesToTruncate.push(statement.column.table);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'drop_pk' || statement.type === 'alter_pk') {
+			const count = await countRows(db, statement.pk.schema, statement.pk.table);
+			if (count > 0) {
+				infoToPrint.push(`You're about to change ${statement.pk.table} primary key`);
+				tablesToTruncate.push(statement.pk.table);
+				shouldAskForApprove = true;
+			}
+		} else if (statement.type === 'add_unique' && selectResolver) {
+			const count = await countRows(db, statement.unique.schema, statement.unique.table);
+			if (count > 0) {
+				const { data } = await selectResolver({
+					entity: {
+						type: 'createUniqueConstraint',
+						name: statement.unique.name,
+						count,
+						tableName: statement.unique.table,
+					},
+					items: ['no', 'yes'],
+				});
+				if (data.index === 1) {
+					statementsToExecute.push(
+						`truncate table ${quotedTable(statement.unique.schema, statement.unique.table)} cascade;`,
+					);
+					tablesToTruncate.push(statement.unique.table);
+					shouldAskForApprove = true;
+				}
+			}
+		}
 
-// 	const db: DB = {
-// 		query: async (query: string) => {
-// 			const res = await drizzleInstance.execute(sql.raw(query));
-// 			return res[0] as unknown as any[];
-// 		},
-// 	};
-// 	const cur = await generateSingleStoreDrizzleJson(imports);
-// 	const { schema: prev } = await singlestorePushIntrospect(db, databaseName, []);
+		statementsToExecute.push(...fromJson([statement]).sqlStatements);
+	}
 
-// 	const validatedPrev = singlestoreSchema.parse(prev);
-// 	const validatedCur = singlestoreSchema.parse(cur);
-
-// 	const squashedPrev = squashSingleStoreScheme(validatedPrev);
-// 	const squashedCur = squashSingleStoreScheme(validatedCur);
-
-// 	const { statements } = await applySingleStoreSnapshotsDiff(
-// 		squashedPrev,
-// 		squashedCur,
-// 		tablesResolver,
-// 		columnsResolver,
-// 		/* singleStoreViewsResolver, */
-// 		validatedPrev,
-// 		validatedCur,
-// 		'push',
-// 	);
-
-// 	const { shouldAskForApprove, statementsToExecute, infoToPrint } = await logSuggestionsAndReturn(
-// 		db,
-// 		statements,
-// 		validatedCur,
-// 		validatedPrev,
-// 	);
-
-// 	return {
-// 		hasDataLoss: shouldAskForApprove,
-// 		warnings: infoToPrint,
-// 		statementsToExecute,
-// 		apply: async () => {
-// 			for (const dStmnt of statementsToExecute) {
-// 				await db.query(dStmnt);
-// 			}
-// 		},
-// 	};
-// };
+	return {
+		statementsToExecute: [...new Set(statementsToExecute)],
+		shouldAskForApprove,
+		infoToPrint,
+		matViewsToRemove: [...new Set(matViewsToRemove)],
+		columnsToRemove: [...new Set(columnsToRemove)],
+		schemasToRemove: [...new Set(schemasToRemove)],
+		tablesToTruncate: [...new Set(tablesToTruncate)],
+		tablesToRemove: [...new Set(tablesToRemove)],
+	};
+};

--- a/drizzle-kit/src/ext/api.ts
+++ b/drizzle-kit/src/ext/api.ts
@@ -29,6 +29,7 @@ import '../@types/utils';
 
 type Queryable = Pool | PoolClient;
 type Named = { name: string; schema?: string; table?: string };
+type TableNamed = Named & { schema: string; table: string };
 type RenamePromptItem<T extends Named> = { from: T; to: T };
 type QueryDB = {
 	query: <T extends any = any>(sql: string, params?: any[]) => Promise<T[]>;
@@ -70,6 +71,20 @@ export type LegacyResolver<T extends Named> = (
 	input: LegacyResolverInput<T>,
 ) => Promise<LegacyResolverOutput<T>>;
 
+export type TableScopedResolverInput<T extends TableNamed> =
+	& Omit<
+		LegacyResolverInput<T>,
+		'schema' | 'tableName'
+	>
+	& {
+		schema: string;
+		tableName: string;
+	};
+
+export type TableScopedResolver<T extends TableNamed> = (
+	input: TableScopedResolverInput<T>,
+) => Promise<LegacyResolverOutput<T>>;
+
 const defaultMigrationsConfig = {
 	schema: 'drizzle',
 	table: '__drizzle_migrations',
@@ -82,17 +97,17 @@ const passthroughResolver = async <T extends Named>({ created, deleted }: Legacy
 export const schemasResolver: LegacyResolver<Schema> = passthroughResolver;
 export const enumsResolver: LegacyResolver<Enum> = passthroughResolver;
 export const sequencesResolver: LegacyResolver<Sequence> = passthroughResolver;
-export const policyResolver: LegacyResolver<Policy> = passthroughResolver;
+export const policyResolver: TableScopedResolver<Policy> = passthroughResolver;
 export const indPolicyResolver: LegacyResolver<Policy> = passthroughResolver;
 export const roleResolver: LegacyResolver<Role> = passthroughResolver;
 export const tablesResolver: LegacyResolver<PostgresEntities['tables']> = passthroughResolver;
-export const columnsResolver: LegacyResolver<Column> = passthroughResolver;
+export const columnsResolver: TableScopedResolver<Column> = passthroughResolver;
 export const viewsResolver: LegacyResolver<View> = passthroughResolver;
 
 export type ResolverInput<T extends Named = Named> = LegacyResolverInput<T>;
-export type ColumnsResolverInput = LegacyResolverInput<Column>;
-export type PolicyResolverInput = LegacyResolverInput<Policy>;
-export type TablePolicyResolverInput = LegacyResolverInput<Policy>;
+export type ColumnsResolverInput = TableScopedResolverInput<Column>;
+export type PolicyResolverInput = TableScopedResolverInput<Policy>;
+export type TablePolicyResolverInput = TableScopedResolverInput<Policy>;
 export type RolesResolverInput = LegacyResolverInput<Role>;
 export type { Enum, Role, Sequence, View };
 export type Table = PostgresEntities['tables'];
@@ -299,6 +314,30 @@ function adaptResolver<T extends Named>(resolver: LegacyResolver<T>): Resolver<T
 	};
 }
 
+function adaptTableScopedResolver<T extends TableNamed>(resolver: TableScopedResolver<T>): Resolver<T> {
+	return async ({ created, deleted }) => {
+		const sample = created[0] ?? deleted[0];
+		if (!sample) return { created, deleted, renamedOrMoved: [] };
+
+		const result = await resolver({
+			created,
+			deleted,
+			schema: sample.schema,
+			tableName: sample.table,
+		});
+
+		return {
+			created: result.created,
+			deleted: result.deleted,
+			renamedOrMoved: [
+				...(result.renamed ?? []),
+				...(result.renamedOrMoved ?? []),
+				...(result.moved ?? []).map((move) => movedToRenamed(move, created, deleted)),
+			],
+		};
+	};
+}
+
 const noOpV1Resolver = async <T extends Named>({ created, deleted }: LegacyResolverInput<T>) => {
 	return { created, deleted, renamedOrMoved: [] };
 };
@@ -309,11 +348,11 @@ export const applyPgSnapshotsDiff = async (
 	schemasResolverArg: LegacyResolver<Schema>,
 	enumsResolverArg: LegacyResolver<Enum>,
 	sequencesResolverArg: LegacyResolver<Sequence>,
-	policyResolverArg: LegacyResolver<Policy>,
+	policyResolverArg: TableScopedResolver<Policy>,
 	_indPolicyResolverArg: LegacyResolver<Policy>,
 	roleResolverArg: LegacyResolver<Role>,
 	tablesResolverArg: LegacyResolver<PostgresEntities['tables']>,
-	columnsResolverArg: LegacyResolver<Column>,
+	columnsResolverArg: TableScopedResolver<Column>,
 	viewsResolverArg: LegacyResolver<View>,
 	_validatedTarget: DrizzlePgDBIntrospectSchema,
 	_validatedSource: DrizzlePgDBIntrospectSchema,
@@ -325,11 +364,11 @@ export const applyPgSnapshotsDiff = async (
 		adaptResolver(schemasResolverArg),
 		adaptResolver(enumsResolverArg),
 		adaptResolver(sequencesResolverArg),
-		adaptResolver(policyResolverArg),
+		adaptTableScopedResolver(policyResolverArg),
 		adaptResolver(roleResolverArg),
 		noOpV1Resolver<Privilege>,
 		adaptResolver(tablesResolverArg),
-		adaptResolver(columnsResolverArg),
+		adaptTableScopedResolver(columnsResolverArg),
 		adaptResolver(viewsResolverArg),
 		noOpV1Resolver<UniqueConstraint>,
 		noOpV1Resolver<Index>,

--- a/drizzle-kit/tests/other/replit-api.test.ts
+++ b/drizzle-kit/tests/other/replit-api.test.ts
@@ -1,0 +1,179 @@
+import type { Pool } from 'pg';
+import { describe, expect, test, vi } from 'vitest';
+import {
+	applyPgSnapshotsDiff,
+	columnsResolver,
+	createEmptyPgSchema,
+	enumsResolver,
+	indPolicyResolver,
+	pgSuggestions,
+	policyResolver,
+	preparePgDB,
+	roleResolver,
+	schemasResolver,
+	sequencesResolver,
+	squashPgScheme,
+	tablesResolver,
+	viewsResolver,
+} from '../../src/ext/api';
+import type { DB } from '../../src/utils';
+
+vi.mock('pg', () => ({
+	default: {
+		types: {
+			builtins: {
+				DATE: 1082,
+				INTERVAL: 1186,
+				TIMESTAMP: 1114,
+				TIMESTAMPTZ: 1184,
+			},
+			getTypeParser: vi.fn(() => (value: unknown) => value),
+		},
+	},
+}));
+
+vi.mock('drizzle-orm/node-postgres', () => ({
+	drizzle: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('drizzle-orm/node-postgres/migrator', () => ({
+	migrate: vi.fn(),
+}));
+
+function createObservedPool() {
+	let activeQueries = 0;
+	let maxActiveQueries = 0;
+
+	const query = vi.fn(async (input: { text: string }) => {
+		activeQueries += 1;
+		maxActiveQueries = Math.max(maxActiveQueries, activeQueries);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		activeQueries -= 1;
+
+		if (input.text === 'fail') throw new Error('query failed');
+		return { rows: [input.text] };
+	});
+
+	return {
+		pool: { query } as unknown as Pool,
+		query,
+		getMaxActiveQueries: () => maxActiveQueries,
+	};
+}
+
+function usersSchema(unique = false) {
+	const ddl = squashPgScheme(createEmptyPgSchema());
+	ddl.tables.push({
+		schema: 'public',
+		name: 'users',
+		isRlsEnabled: false,
+	});
+	ddl.columns.push({
+		schema: 'public',
+		table: 'users',
+		name: 'email',
+		type: 'text',
+		typeSchema: null,
+		notNull: true,
+		dimensions: 0,
+		default: null,
+		generated: null,
+		identity: null,
+	});
+	if (unique) {
+		ddl.uniques.push({
+			schema: 'public',
+			table: 'users',
+			name: 'users_email_unique',
+			nameExplicit: true,
+			columns: ['email'],
+			nullsNotDistinct: false,
+		});
+	}
+
+	return ddl;
+}
+
+async function diffSchemas(
+	target: ReturnType<typeof usersSchema>,
+	source: ReturnType<typeof usersSchema>,
+) {
+	const emptySchema = createEmptyPgSchema();
+	return applyPgSnapshotsDiff(
+		target,
+		source,
+		schemasResolver,
+		enumsResolver,
+		sequencesResolver,
+		policyResolver,
+		indPolicyResolver,
+		roleResolver,
+		tablesResolver,
+		columnsResolver,
+		viewsResolver,
+		emptySchema,
+		emptySchema,
+		'push',
+	);
+}
+
+describe('preparePgDB', () => {
+	test('limits query and proxy concurrency and resumes after rejection', async () => {
+		const observed = createObservedPool();
+		const db = await preparePgDB(observed.pool, { queryConcurrency: 2 });
+
+		const results = await Promise.allSettled([
+			db.query('select 1'),
+			db.query('fail'),
+			db.query('select 2'),
+			db.proxy({ method: 'all', mode: 'array', params: [], sql: 'select 3' }),
+		]);
+
+		expect(results.map((result) => result.status)).toEqual(['fulfilled', 'rejected', 'fulfilled', 'fulfilled']);
+		expect(observed.query).toHaveBeenCalledTimes(4);
+		expect(observed.getMaxActiveQueries()).toBe(2);
+	});
+
+	test('rejects invalid query concurrency', async () => {
+		const observed = createObservedPool();
+		await expect(preparePgDB(observed.pool, { queryConcurrency: 0 })).rejects.toThrow(
+			'queryConcurrency must be a positive integer',
+		);
+	});
+});
+
+describe('Replit compatibility API', () => {
+	test('generates executable SQL through the legacy resolver contract', async () => {
+		const result = await diffSchemas(squashPgScheme(createEmptyPgSchema()), usersSchema());
+
+		expect(result.sqlStatements.join('\n')).toContain('CREATE TABLE "users"');
+		expect(result.sqlStatements.join('\n')).toContain('"email" text NOT NULL');
+	});
+
+	test('reports destructive changes only when the target contains data', async () => {
+		const result = await diffSchemas(usersSchema(), squashPgScheme(createEmptyPgSchema()));
+		const db: DB = {
+			query: vi.fn().mockResolvedValue([{ count: '3' }]),
+		};
+
+		const suggestions = await pgSuggestions(db, result.statements);
+
+		expect(suggestions.shouldAskForApprove).toBe(true);
+		expect(suggestions.tablesToRemove).toEqual(['users']);
+		expect(suggestions.statementsToExecute.join('\n')).toContain('DROP TABLE "users"');
+	});
+
+	test('places an approved truncate before a new unique constraint', async () => {
+		const result = await diffSchemas(usersSchema(), usersSchema(true));
+		const db: DB = {
+			query: vi.fn().mockResolvedValue([{ count: '2' }]),
+		};
+		const selectResolver = vi.fn().mockResolvedValue({ data: { index: 1, value: 'yes' } });
+
+		const suggestions = await pgSuggestions(db, result.statements, selectResolver);
+
+		expect(suggestions.tablesToTruncate).toEqual(['users']);
+		expect(suggestions.statementsToExecute[0]).toBe('truncate table "users" cascade;');
+		expect(suggestions.statementsToExecute.join('\n')).toContain('UNIQUE');
+	});
+});


### PR DESCRIPTION
## What changed

Adds the internal `@drizzle-team/drizzle-kit` artifact and pid2-facing database diff API on top of Drizzle Kit RC4. It preserves capped Postgres introspection concurrency, legacy conflict resolvers, generated SQL, and structural data-loss reporting without changing the upstream workspace package identity.

## Why

Pid2 needs low-level introspection and interactive diff hooks that upstream Drizzle Kit does not export. Keeping the source workspace named `drizzle-kit` lets upstream CI continue to operate normally, while `pack:replit` rewrites only the internal tarball manifest.

## What changed

- Adds the `./api` CJS, ESM, and declaration bundles.
- Adapts pid2 resolver callbacks to RC4 DDL resolvers.
- Caps shared query and proxy concurrency through `preparePgDB`.
- Preserves destructive-change classification and unique-constraint prompts.
- Adds explicit `pack:replit` and `publish:replit` commands for the scoped internal artifact.
- Removes bundled Brocli from only the internal manifest because Replit routes the `@drizzle-team` scope to Artifact Registry.

## Test plan

- `pnpm lint:check`
- `pnpm --filter drizzle-kit test:types`
- `pnpm --dir drizzle-kit exec vitest run tests/other/replit-api.test.ts` (5 passed)
- `pnpm --filter drizzle-kit pack:replit`
- Typechecked and loaded the packed artifact through CJS and ESM with `drizzle-orm@0.45.2`, `pg@8.5.1`, and `@types/pg@8.15.5`.
- Installed the tarball into a disposable current `repl-it-web` worktree, passed the full pid2 typecheck after the expected schema-shape migration, and passed 7 focused database-diff tests.

## Stack

- #28 syncs the fork to the exact upstream RC4 tree.
- This PR adds only Replit-specific package and pid2 compatibility.

## Rollout and rollback

Do not publish until both PRs merge. Publishing and the pid2 dependency bump remain separate, explicitly gated steps. The source change is safe to revert before publication and does not modify persistent data.

~ written by Zerg :space_invader: ([wp-961c729b](https://zerg.zergrush.dev/chat?id=wp-961c729b))